### PR TITLE
feat: add git_analysis module and handlers for each CLI mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +100,8 @@ version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -93,6 +110,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "console"
@@ -221,12 +252,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -234,6 +281,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -253,10 +328,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -276,6 +357,21 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "h2"
@@ -371,6 +467,29 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -548,6 +667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +690,46 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.0+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -602,8 +770,11 @@ name = "merit-cli-demo"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "dialoguer",
  "dotenv",
+ "futures",
+ "git2",
  "indicatif",
  "reqwest",
  "serde_json",
@@ -651,6 +822,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1342,6 +1522,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0.138"
 dotenv = "0.15.0"
 indicatif = "0.17.11"
+git2 = "0.20.0"
+chrono = "0.4.39"
+futures = "0.3.31"

--- a/src/git_analysis.rs
+++ b/src/git_analysis.rs
@@ -1,0 +1,90 @@
+use std::error::Error;
+use std::fmt::Debug;
+use async_trait::async_trait;
+
+use crate::providers::Provider;
+
+/// Trait for git-specific model behavior
+#[async_trait]
+pub trait GitAnalyzer: Debug {
+    fn name(&self) -> &str;
+    async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>>;
+    async fn analyze_file_changes(&self, diff: &str) -> Result<String, Box<dyn Error>>;
+    async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>>;
+}
+
+/// Implementation of GitAnalyzer that uses any Provider
+#[derive(Debug)]
+pub struct GitAnalyzerImpl {
+    provider: Box<dyn Provider>,
+}
+
+impl GitAnalyzerImpl {
+    pub fn new(provider: Box<dyn Provider>) -> Self {
+        Self { provider }
+    }
+}
+
+#[async_trait]
+impl GitAnalyzer for GitAnalyzerImpl {
+    fn name(&self) -> &str {
+        self.provider.name()
+    }
+
+    async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.provider.generate_text(SYSTEM_MESSAGE, diff, 0.7).await
+    }
+
+    async fn analyze_file_changes(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.provider.generate_text(FILE_ANALYSIS_PROMPT, diff, 0.7).await
+    }
+
+    async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>> {
+        self.provider.generate_text(CONTRIBUTOR_ANALYSIS_PROMPT, stats, 0.7).await
+    }
+}
+
+pub fn wrap_provider(provider: Box<dyn Provider>) -> Box<dyn GitAnalyzer> {
+    Box::new(GitAnalyzerImpl::new(provider))
+}
+
+const SYSTEM_MESSAGE: &str = r#"You are an expert software developer tasked with writing clear, concise, and informative git commit messages following the Conventional Commits specification. Given a git diff, you will:
+
+1. Analyze the changes to understand what was modified
+2. Create a commit message following these rules:
+   - Use the conventional commit format: <type>: <description>
+   - Common types are: feat (new feature), fix (bug fix), docs (documentation), style (formatting), refactor, test, chore
+   - The description should use imperative mood ("Add feature" not "Added feature")
+   - The entire message should be 50 chars or less
+   - Focus on the "why" and "what" rather than the "how"
+
+Please provide only the commit message without any additional commentary."#;
+
+const FILE_ANALYSIS_PROMPT: &str = r#"You are an expert software developer tasked with analyzing changes to a file. Given a git diff or file content, you will:
+
+1. Analyze the changes to understand what was modified
+2. The following could be relevant to the changes:
+   - What functionality was added, modified, or removed
+   - Any potential impact on the codebase
+   - Notable implementation details or design decisions
+   - Any potential concerns or suggestions for improvement
+
+Try to be as concise as possible while still providing meaningful insights.
+
+Please focus on providing meaningful insights rather than just describing the changes line by line."#;
+
+const CONTRIBUTOR_ANALYSIS_PROMPT: &str = r#"You are an expert software developer tasked with analyzing a contributor's work in a repository. Given information about their commits, files changed, and overall impact, you will:
+
+1. Analyze their contributions to understand their role and impact:
+   - Primary areas of focus and expertise
+   - Types of changes they typically make
+   - Impact on the codebase architecture and quality
+   - Notable patterns in their work
+
+2. Provide a concise but comprehensive summary that covers:
+   - Their main areas of contribution
+   - The significance of their changes
+   - Their apparent role in the project
+   - Any notable patterns or specialties in their work
+
+Please provide a clear, professional summary that helps understand the contributor's role and impact on the project."#; 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,57 @@
 use std::error::Error;
+use git2::Repository;
+use futures::future;
 
 pub mod providers;
 pub mod ui;
 pub mod modes;
+pub mod git;
+pub mod git_analysis;
+
+#[derive(Debug)]
+pub struct Config {
+    model: Box<dyn git_analysis::GitAnalyzer>,
+}
+
+#[derive(Debug)]
+pub struct FileAnalysis {
+    pub path: String,
+    pub explanation: String,
+}
+
+impl Config {
+    pub fn new(model: Box<dyn git_analysis::GitAnalyzer>) -> Self {
+        Self { model }
+    }
+
+    pub async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.model.generate_commit_message(diff).await
+    }
+
+    pub async fn analyze_changes(&self, repo: &Repository) -> Result<Vec<FileAnalysis>, Box<dyn Error>> {
+        let file_diffs = git::get_file_diffs(repo)?;
+        
+        let analysis_futures: Vec<_> = file_diffs.into_iter().map(|(path, diff)| {
+            let model = &self.model;
+            async move {
+                let explanation = model.analyze_file_changes(&diff).await?;
+                Ok::<FileAnalysis, Box<dyn Error>>(FileAnalysis {
+                    path,
+                    explanation,
+                })
+            }
+        }).collect();
+
+        future::join_all(analysis_futures)
+            .await
+            .into_iter()
+            .collect()
+    }
+
+    pub async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>> {
+        self.model.analyze_contributor(stats).await
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -10,19 +59,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let providers = providers::get_available_providers();
 
-    println!("Available providers:");
-    for (i, provider) in providers.iter().enumerate() {
-        println!("{}: {}", i, provider.name());
-    }
-
     let selected_idx = providers::select_provider(&providers)?;
-    let provider = &providers[selected_idx];
-
-    println!("Selected provider: {}", provider.name());
 
     let mode = ui::select_mode().await?;
 
-    println!("Selected mode: {}", mode.description());
+    let repo = git2::Repository::open(".")?;
+
+    let config = Config::new(git_analysis::wrap_provider(providers.into_iter().nth(selected_idx).unwrap()));
+
+    mode.execute(&config, &repo).await?;
 
     Ok(())
 }

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -1,3 +1,10 @@
+use std::error::Error;
+use git2::Repository;
+
+use crate::git;
+use crate::ui;
+use crate::Config;
+
 #[derive(Debug)]
 pub enum Mode {
     CommitMessage,
@@ -13,4 +20,238 @@ impl Mode {
             Mode::ContributorAnalysis => "Analyze contributors",
         }
     }
+
+    pub async fn execute(&self, config: &Config, repo: &Repository) -> Result<(), Box<dyn Error>> {
+        match self {
+            Mode::CommitMessage => handle_commit_message(config, repo).await,
+            Mode::FileAnalysis => handle_file_analysis(config, repo).await,
+            Mode::ContributorAnalysis => handle_contributor_analysis(config, repo).await,
+        }
+    }
 }
+
+async fn handle_commit_message(config: &Config, repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let diff = git::get_diff(repo)?;
+    
+    loop {
+        let commit_message = generate_with_spinner(config, &diff).await?;
+        
+        let options = [
+            "✨ Regenerate message",
+            "📝 Edit commit type",
+            "✅ Stage and commit",
+            "❌ Cancel"
+        ];
+        
+        match ui::show_selection_menu("What would you like to do?", &options, 2)? {
+            0 => continue, // Regenerate
+            1 => {
+                let types = [
+                    "feat: New feature",
+                    "fix: Bug fix",
+                    "docs: Documentation",
+                    "style: Formatting",
+                    "refactor: Code restructure",
+                    "test: Testing",
+                    "chore: Maintenance",
+                ];
+                
+                let type_idx = ui::show_selection_menu("Select commit type", &types, 0)?;
+                let selected_type = types[type_idx].split(':').next().unwrap();
+                let description = commit_message.split(':').nth(1).unwrap_or(&commit_message).trim();
+                let new_message = format!("{}: {}", selected_type, description);
+                
+                println!("\n📝 New Commit Message");
+                println!("══════════════════════");
+                println!("{}\n", new_message);
+
+                let confirm_options = ["✅ Confirm and commit", "🔄 Start over", "❌ Cancel"];
+                match ui::show_selection_menu("Would you like to proceed with this commit message?", &confirm_options, 0)? {
+                    0 => {
+                        git::stage_and_commit(repo, &new_message)?;
+                        println!("Changes committed successfully!");
+                        break;
+                    }
+                    1 => continue,
+                    _ => break,
+                }
+            }
+            2 => {
+                git::stage_and_commit(repo, &commit_message)?;
+                println!("Changes committed successfully!");
+                break;
+            }
+            _ => break,
+        }
+    }
+    Ok(())
+}
+
+async fn handle_file_analysis(config: &Config, repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let spinner = ui::create_spinner("Analyzing changes")?;
+    let analyses = config.analyze_changes(repo).await?;
+    spinner.finish_and_clear();
+    
+    println!("\n📊 File Analysis Results");
+    println!("══════════════════════\n");
+    
+    for analysis in analyses {
+        println!("📁 {}", analysis.path);
+        println!("───────────────────");
+        println!("{}\n", analysis.explanation);
+    }
+    
+    Ok(())
+}
+
+async fn handle_contributor_analysis(config: &Config, repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let contributors = git::get_contributors(repo)?;
+    
+    println!("\n👥 Repository Contributors");
+    println!("═════════════════════════\n");
+    
+    let mut contributor_items: Vec<String> = contributors.iter().map(|c| {
+        format!("{} <{}> ({} commits)", c.name, c.email, c.commit_count)
+    }).collect();
+    contributor_items.push("❌ Exit".to_string());
+
+    loop {
+        let selection = ui::show_selection_menu("Select a contributor to view details", &contributor_items, 0)?;
+
+        if selection == contributor_items.len() - 1 {
+            break;
+        }
+
+        let contributor = &contributors[selection];
+        display_contributor_info(contributor);
+        
+        let spinner = ui::create_spinner("Analyzing contributor's work")?;
+        let stats = format_contributor_stats(contributor, repo)?;
+        let summary = config.analyze_contributor(&stats).await?;
+        spinner.finish_and_clear();
+
+        println!("\n🤖 AI Analysis");
+        println!("═════════════");
+        println!("{}\n", summary);
+
+        println!("\nPress Enter to continue...");
+        std::io::stdin().read_line(&mut String::new())?;
+        println!("\x1B[2J\x1B[1;1H"); // Clear screen
+    }
+
+    Ok(())
+}
+
+async fn generate_with_spinner(config: &Config, diff: &str) -> Result<String, Box<dyn Error>> {
+    let spinner = ui::create_spinner("Generating commit message")?;
+    let commit_message = config.generate_commit_message(diff).await?;
+    spinner.finish_and_clear();
+
+    println!("\n📝 Generated Commit Message");
+    println!("══════════════════════════");
+    println!("{}\n", commit_message);
+    
+    Ok(commit_message)
+}
+
+fn display_contributor_info(contributor: &git::ContributorStats) {
+    println!("\n👤 Contributor Details: {}", contributor.name);
+    println!("══════════════════════════════");
+    println!("📧 Email: {}", contributor.email);
+    
+    println!("\n📊 Statistics");
+    println!("───────────");
+    println!("  • Commits: {}", contributor.commit_count);
+    println!("  • Lines added: {}", contributor.additions);
+    println!("  • Lines deleted: {}", contributor.deletions);
+    println!("  • Files changed: {}", contributor.files_changed.len());
+
+    println!("\n📁 Most Modified Files");
+    println!("──────────────────");
+    for (file, count) in &contributor.most_modified_files {
+        println!("  • {} ({} modifications)", file, count);
+    }
+
+    println!("\n🔧 File Types");
+    println!("────────────");
+    let mut file_types: Vec<_> = contributor.file_types.iter().collect();
+    file_types.sort_by(|a, b| b.1.cmp(a.1));
+    for (ext, count) in file_types {
+        println!("  • {}: {} files", ext, count);
+    }
+
+    println!("\n📈 Largest Contributions");
+    println!("─────────────────────");
+    for (additions, deletions, message) in &contributor.largest_commits {
+        println!("  • +{} -{} : {}", additions, deletions, message);
+    }
+}
+
+fn format_contributor_stats(
+    contributor: &git::ContributorStats,
+    repo: &Repository,
+) -> Result<String, Box<dyn Error>> {
+    let commits = git::get_contributor_commits(
+        repo,
+        &contributor.name,
+        &contributor.email
+    )?;
+
+    println!("\n🔄 Recent Commits");
+    println!("───────────────");
+    for commit in commits.iter().take(5) {
+        println!("• {}", commit);
+    }
+
+    Ok(format!(
+        "Contributor: {} <{}>
+
+Statistics:
+- Total commits: {}
+- Lines added: {}
+- Lines deleted: {}
+- Files modified: {}
+
+Most frequently modified files:
+{}
+
+File type distribution:
+{}
+
+Largest contributions:
+{}
+
+Recent commits:
+{}
+
+Modified files:
+{}",
+        contributor.name,
+        contributor.email,
+        contributor.commit_count,
+        contributor.additions,
+        contributor.deletions,
+        contributor.files_changed.len(),
+        contributor.most_modified_files.iter()
+            .map(|(file, count)| format!("- {} ({} modifications)", file, count))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        contributor.file_types.iter()
+            .map(|(ext, count)| format!("- {}: {} files", ext, count))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        contributor.largest_commits.iter()
+            .map(|(add, del, msg)| format!("- +{} -{} : {}", add, del, msg))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        commits.iter()
+            .take(5)
+            .map(|c| format!("- {}", c))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        contributor.files_changed.iter()
+            .map(|f| format!("- {}", f))
+            .collect::<Vec<_>>()
+            .join("\n")
+    ))
+} 


### PR DESCRIPTION
Create a module for handling each of the CLI modes. `GitAnalyzer` instances can be created with a `Provider` trait object.