### PR TITLE
feat: add markdown formatting for LLM outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,7 +49,7 @@ checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -85,6 +109,8 @@ version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -95,6 +121,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "console"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,8 +143,17 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "coolor"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691defa50318376447a73ced869862baecfab35f6aabaa91a4cd726b315bfe1a"
+dependencies = [
+ "crossterm",
 ]
 
 [[package]]
@@ -122,6 +171,113 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crokey"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520e83558f4c008ac06fa6a86e5c1d4357be6f994cce7434463ebcdaadf47bb1"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370956e708a1ce65fe4ac5bb7185791e0ece7485087f17736d54a23a0895049f"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.8.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "dialoguer"
@@ -144,7 +300,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -221,12 +377,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -234,6 +406,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "futures-sink"
@@ -253,10 +453,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -276,6 +482,21 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "h2"
@@ -371,6 +592,29 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -488,7 +732,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -531,7 +775,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
 ]
 
@@ -548,6 +792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,10 +811,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.0+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -602,11 +918,15 @@ name = "merit-cli-demo"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "dialoguer",
  "dotenv",
+ "futures",
+ "git2",
  "indicatif",
  "reqwest",
  "serde_json",
+ "termimad",
  "tokio",
 ]
 
@@ -615,6 +935,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimad"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -632,6 +961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -651,6 +981,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -697,7 +1036,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -797,6 +1136,35 @@ checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.8.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -933,7 +1301,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -971,6 +1339,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1013,6 +1402,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,7 +1443,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1076,6 +1482,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "termimad"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e19c6dbf107bec01d0e216bb8219485795b7d75328e4fa5ef2756c1be4f8dc"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,7 +1514,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1131,7 +1553,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1193,6 +1615,12 @@ name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -1275,7 +1703,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -1310,7 +1738,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1342,6 +1770,37 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1543,7 +2002,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -1564,7 +2023,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -1593,5 +2052,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0.138"
 dotenv = "0.15.0"
 indicatif = "0.17.11"
+git2 = "0.20.0"
+chrono = "0.4.39"
+futures = "0.3.31"
+termimad = "0.31.2"

--- a/src/git_analysis.rs
+++ b/src/git_analysis.rs
@@ -1,0 +1,92 @@
+use std::error::Error;
+use std::fmt::Debug;
+use async_trait::async_trait;
+
+use crate::providers::Provider;
+
+/// Trait for git-specific model behavior
+#[async_trait]
+pub trait GitAnalyzer: Debug {
+    fn name(&self) -> &str;
+    async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>>;
+    async fn analyze_file_changes(&self, diff: &str) -> Result<String, Box<dyn Error>>;
+    async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>>;
+}
+
+/// Implementation of GitAnalyzer that uses any Provider
+#[derive(Debug)]
+pub struct GitAnalyzerImpl {
+    provider: Box<dyn Provider>,
+}
+
+impl GitAnalyzerImpl {
+    pub fn new(provider: Box<dyn Provider>) -> Self {
+        Self { provider }
+    }
+}
+
+#[async_trait]
+impl GitAnalyzer for GitAnalyzerImpl {
+    fn name(&self) -> &str {
+        self.provider.name()
+    }
+
+    async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.provider.generate_text(SYSTEM_MESSAGE, diff, 0.7).await
+    }
+
+    async fn analyze_file_changes(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.provider.generate_text(FILE_ANALYSIS_PROMPT, diff, 0.7).await
+    }
+
+    async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>> {
+        self.provider.generate_text(CONTRIBUTOR_ANALYSIS_PROMPT, stats, 0.7).await
+    }
+}
+
+pub fn wrap_provider(provider: Box<dyn Provider>) -> Box<dyn GitAnalyzer> {
+    Box::new(GitAnalyzerImpl::new(provider))
+}
+
+const SYSTEM_MESSAGE: &str = r#"You are an expert software developer tasked with writing clear, concise, and informative git commit messages following the Conventional Commits specification. Given a git diff, you will:
+
+1. Analyze the changes to understand what was modified
+2. Create a commit message following these rules:
+   - Use the conventional commit format: <type>: <description>
+   - Common types are: feat (new feature), fix (bug fix), docs (documentation), style (formatting), refactor, test, chore
+   - The description should use imperative mood ("Add feature" not "Added feature")
+   - The entire message should be 50 chars or less
+   - Focus on the "why" and "what" rather than the "how"
+
+Please provide only the commit message without any additional commentary or markdown formatting."#;
+
+const FILE_ANALYSIS_PROMPT: &str = r#"You are an expert software developer tasked with analyzing changes to a file. Given a git diff or file content, you will:
+
+1. Analyze the changes to understand what was modified
+2. The following could be relevant to the changes:
+   - What functionality was added, modified, or removed
+   - Any potential impact on the codebase
+   - Notable implementation details or design decisions
+   - Any potential concerns or suggestions for improvement
+
+Format your response in markdown with appropriate headers, lists, and code blocks where relevant.
+Do not include ``` tags in your response unless you are explicitly using them to format code. Do not include ```markdown!
+Try to be as concise as possible while still providing meaningful insights.
+Please focus on providing meaningful insights rather than just describing the changes line by line."#;
+
+const CONTRIBUTOR_ANALYSIS_PROMPT: &str = r#"You are an expert software developer tasked with analyzing a contributor's work in a repository. Given information about their commits, files changed, and overall impact, you will:
+
+1. Analyze their contributions to understand their role and impact:
+   - Primary areas of focus and expertise
+   - Types of changes they typically make
+   - Impact on the codebase architecture and quality
+   - Notable patterns in their work
+
+2. Provide a concise but comprehensive summary that covers:
+   - Their main areas of contribution
+   - The significance of their changes
+   - Their apparent role in the project
+   - Any notable patterns or specialties in their work
+
+Format your response in markdown with appropriate headers, lists, and emphasis where relevant.
+Please provide a clear, professional summary that helps understand the contributor's role and impact on the project."#; 

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -1,3 +1,10 @@
+use std::error::Error;
+use git2::Repository;
+
+use crate::git;
+use crate::ui;
+use crate::Config;
+
 #[derive(Debug)]
 pub enum Mode {
     CommitMessage,
@@ -8,9 +15,259 @@ pub enum Mode {
 impl Mode {
     pub fn description(&self) -> &'static str {
         match self {
-            Mode::CommitMessage => "Generate commit message",
-            Mode::FileAnalysis => "Analyze file changes",
-            Mode::ContributorAnalysis => "Analyze contributors",
+            Mode::CommitMessage => "📝 Generate commit message",
+            Mode::FileAnalysis => "🔍 Analyze file changes", 
+            Mode::ContributorAnalysis => "👥 Analyze contributors",
+        }
+    }
+
+    pub async fn execute(&self, config: &Config, repo: &Repository) -> Result<(), Box<dyn Error>> {
+        match self {
+            Mode::CommitMessage => handle_commit_message(config, repo).await,
+            Mode::FileAnalysis => handle_file_analysis(config, repo).await,
+            Mode::ContributorAnalysis => handle_contributor_analysis(config, repo).await,
         }
     }
 }
+
+async fn handle_commit_message(config: &Config, repo: &Repository) -> Result<(), Box<dyn Error>> {
+    match git::get_diff(repo) {
+        Ok(diff) => {
+            loop {
+                let commit_message = generate_with_spinner(config, &diff).await?;
+                
+                let options = [
+                    "✨ Regenerate message",
+                    "📝 Edit commit type",
+                    "✅ Stage and commit",
+                    "❌ Cancel"
+                ];
+                
+                match ui::show_selection_menu("What would you like to do?", &options, 2)? {
+                    0 => continue, // Regenerate
+                    1 => {
+                        let types = [
+                            "feat: ✨ New feature",
+                            "fix: 🐛 Bug fix", 
+                            "docs: 📚 Documentation",
+                            "style: 💅 Formatting",
+                            "refactor: ♻️ Code restructure",
+                            "test: 🧪 Testing",
+                            "chore: 🔧 Maintenance",
+                        ];
+                        
+                        let type_idx = ui::show_selection_menu("Select commit type", &types, 0)?;
+                        let selected_type = types[type_idx].split(':').next().unwrap();
+                        let description = commit_message.split(':').nth(1).unwrap_or(&commit_message).trim();
+                        let new_message = format!("{}: {}", selected_type, description);
+                        
+                        ui::print_section("📝 New Commit Message");
+                        println!("{}\n", new_message);
+
+                        let confirm_options = [
+                            "✅ Confirm and commit", 
+                            "🔄 Start over", 
+                            "❌ Cancel"
+                        ];
+                        match ui::show_selection_menu("Would you like to proceed with this commit message?", &confirm_options, 0)? {
+                            0 => {
+                                git::stage_and_commit(repo, &new_message)?;
+                                println!("Changes committed successfully!");
+                                break;
+                            }
+                            1 => continue,
+                            _ => break,
+                        }
+                    }
+                    2 => {
+                        git::stage_and_commit(repo, &commit_message)?;
+                        println!("Changes committed successfully!");
+                        break;
+                    }
+                    _ => break,
+                }
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if e.to_string() == "No changes to commit" {
+                ui::print_section("📝 Repository Status");
+                println!("No changes to commit. Your working directory is clean.\n");
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+async fn handle_file_analysis(config: &Config, repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let spinner = ui::create_spinner("Analyzing changes")?;
+    let result = config.analyze_changes(repo).await;
+    spinner.finish_and_clear();
+    
+    match result {
+        Ok(analyses) => {
+            ui::print_section("📊 File Analysis Results");
+            
+            for analysis in analyses {
+                let markdown = format!("## 📁 {}\n{}", analysis.path, analysis.explanation);
+                ui::print_markdown(&markdown);
+            }
+            
+            Ok(())
+        }
+        Err(e) => {
+            if e.to_string() == "No changes to commit" {
+                ui::print_section("📊 Repository Status");
+                println!("No changes to analyze. Your working directory is clean.\n");
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+async fn handle_contributor_analysis(config: &Config, repo: &Repository) -> Result<(), Box<dyn Error>> {
+    let contributors = git::get_contributors(repo)?;
+    
+    ui::print_section("👥 Repository Contributors");
+    
+    let mut contributor_items: Vec<String> = contributors.iter().map(|c| {
+        format!("{} <{}> ({} commits)", c.name, c.email, c.commit_count)
+    }).collect();
+    contributor_items.push("❌ Exit".to_string());
+
+    loop {
+        let selection = ui::show_selection_menu("Select a contributor to view details", &contributor_items, 0)?;
+
+        if selection == contributor_items.len() - 1 {
+            break;
+        }
+
+        let contributor = &contributors[selection];
+        display_contributor_info(contributor);
+        
+        let stats = format_contributor_stats(contributor, repo)?;
+        let spinner = ui::create_spinner("Analyzing contributor's work")?;
+        let summary = config.analyze_contributor(&stats).await?;
+        spinner.finish_and_clear();
+        
+        ui::print_section("🤖 AI Analysis");
+        ui::print_markdown(&summary);
+
+        println!("\nPress Enter to continue...");
+        std::io::stdin().read_line(&mut String::new())?;
+        println!("\x1B[2J\x1B[1;1H"); // Clear screen
+    }
+
+    Ok(())
+}
+
+async fn generate_with_spinner(config: &Config, diff: &str) -> Result<String, Box<dyn Error>> {
+    let spinner = ui::create_spinner("Generating commit message")?;
+    let commit_message = config.generate_commit_message(diff).await?;
+    spinner.finish_and_clear();
+
+    ui::print_section("📝 Generated Commit Message");
+    println!("{}\n", commit_message);
+    
+    Ok(commit_message)
+}
+
+fn display_contributor_info(contributor: &git::ContributorStats) {
+    ui::print_section(&format!("👤 Contributor Details: {}", contributor.name));
+    println!("📧 Email: {}", contributor.email);
+    
+    ui::print_subsection("📊 Statistics");
+    println!("  • Commits: {}", contributor.commit_count);
+    println!("  • Lines added: {}", contributor.additions);
+    println!("  • Lines deleted: {}", contributor.deletions);
+    println!("  • Files changed: {}", contributor.files_changed.len());
+
+    ui::print_subsection("📁 Most Modified Files");
+    for (file, count) in &contributor.most_modified_files {
+        println!("  • {} ({} modifications)", file, count);
+    }
+
+    ui::print_subsection("🔧 File Types");
+    let mut file_types: Vec<_> = contributor.file_types.iter().collect();
+    file_types.sort_by(|a, b| b.1.cmp(a.1));
+    for (ext, count) in file_types {
+        println!("  • {}: {} files", ext, count);
+    }
+
+    ui::print_subsection("📈 Largest Contributions");
+    for (additions, deletions, message) in &contributor.largest_commits {
+        println!("  • +{} -{} : {}", additions, deletions, message);
+    }
+}
+
+fn format_contributor_stats(
+    contributor: &git::ContributorStats,
+    repo: &Repository,
+) -> Result<String, Box<dyn Error>> {
+    let commits = git::get_contributor_commits(
+        repo,
+        &contributor.name,
+        &contributor.email
+    )?;
+
+    ui::print_subsection("🔄 Recent Commits");
+    for commit in commits.iter().take(5) {
+        println!("• {}", commit);
+    }
+
+    Ok(format!(
+        "## Contributor: {} <{}>
+
+### Statistics
+- Total commits: {}
+- Lines added: {}
+- Lines deleted: {}
+- Files modified: {}
+
+### Most frequently modified files
+{}
+
+### File type distribution
+{}
+
+### Largest contributions
+{}
+
+### Recent commits
+{}
+
+### Modified files
+{}",
+        contributor.name,
+        contributor.email,
+        contributor.commit_count,
+        contributor.additions,
+        contributor.deletions,
+        contributor.files_changed.len(),
+        contributor.most_modified_files.iter()
+            .map(|(file, count)| format!("- {} ({} modifications)", file, count))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        contributor.file_types.iter()
+            .map(|(ext, count)| format!("- {}: {} files", ext, count))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        contributor.largest_commits.iter()
+            .map(|(add, del, msg)| format!("- +{} -{} : {}", add, del, msg))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        commits.iter()
+            .take(5)
+            .map(|c| format!("- {}", c))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        contributor.files_changed.iter()
+            .map(|f| format!("- {}", f))
+            .collect::<Vec<_>>()
+            .join("\n")
+    ))
+} 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,8 +1,38 @@
 use std::error::Error;
-use dialoguer::{theme::ColorfulTheme, Select};
+use dialoguer::{theme::ColorfulTheme, Select, Input};
 use indicatif::{ProgressBar, ProgressStyle};
+use termimad::{MadSkin, gray, StyledChar};
 
 use crate::modes::Mode;
+
+/// Renders markdown text in the terminal with proper styling
+pub fn print_markdown(text: &str) {
+    let mut skin = MadSkin::default();
+    // Configure markdown styling
+    skin.set_headers_fg(gray(255));  // Bright white for headers
+    skin.bold.set_fg(gray(200));     // Light gray for bold
+    skin.italic.set_fg(gray(180));   // Slightly darker for italic
+    skin.bullet = StyledChar::from_fg_char(gray(180), '•');
+    skin.quote_mark = StyledChar::from_fg_char(gray(180), '▐');
+    skin.code_block.set_fg(gray(71)); // Light green for code blocks
+    
+    // Add a newline before and after for better spacing
+    println!();
+    skin.print_text(text);
+    println!();
+}
+
+/// Prints a section header with a title
+pub fn print_section(title: &str) {
+    println!("\n{}", title);
+    println!("{}\n", "═".repeat(title.chars().count()));
+}
+
+/// Prints a subsection header with a title
+pub fn print_subsection(title: &str) {
+    println!("\n{}", title);
+    println!("{}", "─".repeat(title.chars().count()));
+}
 
 pub fn create_spinner(message: &str) -> Result<ProgressBar, Box<dyn Error>> {
     let spinner = ProgressBar::new_spinner();
@@ -38,4 +68,13 @@ pub async fn select_mode() -> Result<Mode, Box<dyn Error>> {
         1 => Mode::FileAnalysis,
         _ => Mode::ContributorAnalysis,
     })
+}
+
+pub fn get_repository_path(default: &str) -> Result<String, Box<dyn Error>> {
+    let path: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter repository path")
+        .default(default.into())
+        .allow_empty(true)
+        .interact()?;
+    Ok(if path.is_empty() { ".".to_string() } else { path })
 }


### PR DESCRIPTION
Add markdown formatting for displaying LLM responses. Instruct LLM to use markdown for all contributor and file analysis.
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/b38459a3-b068-429f-b0b7-04df22d0fad4" />
